### PR TITLE
fix: update emitter event matching logic

### DIFF
--- a/src/emitter_bus.ts
+++ b/src/emitter_bus.ts
@@ -20,7 +20,7 @@ export function create_bus(log: Logger) {
       on_reply_from_extension: (event_name, reply) => {
         const listener = (emitter_data: any) => {
           log.debug(`[bus] received from Extension`, emitter_data);
-          if (emitter_data && emitter_data.__event === event_name) {
+          if (emitter_data && emitter_data.__request_id && event_name.endsWith(emitter_data.__request_id)) {
             reply(emitter_data);
           }
         };


### PR DESCRIPTION
# Fix for get-shape-categories Tool Hanging Issue

## Problem Description

The `get-shape-categories` MCP tool call was hanging indefinitely instead of returning the shape categories from Draw.io. This issue affected the tool's ability to retrieve available shape categories from the diagram's library.

## Root Cause Analysis

The issue was located in the reply matching logic within the `emitter_bus.ts` file. Here's what was happening:

### The Broken Flow

1. **Request Generation** (`tool.ts` line 19):
   ```typescript
   const reply_name = `${event_name}.${request_id}`;
   // Example: "get-shape-categories.abc123"
   ```

2. **Request Sent to Extension**:
   ```json
   {
     "__event": "get-shape-categories",
     "__request_id": "abc123"
   }
   ```

3. **Extension Response**:
   ```json
   {
     "__event": "get-shape-categories",
     "__request_id": "abc123",
     "categories": [...]
   }
   ```

4. **Failed Reply Matching** (`emitter_bus.ts` line 21):
   ```typescript
   if (emitter_data && emitter_data.__event === event_name) {
   ```

   This was comparing:
   - `emitter_data.__event`: `"get-shape-categories"`
   - `event_name`: `"get-shape-categories.abc123"`

   **Result**: No match → Promise never resolves → Tool hangs

## The Fix

### File Modified: `./src/emitter_bus.ts`

**Before** (lines 18-24):
```typescript
on_reply_from_extension: (event_name, reply) => {
  const listener = (emitter_data: any) => {
    log.debug(`[bus] received from Extension`, emitter_data);
    if (emitter_data && emitter_data.__event === event_name) {
      reply(emitter_data);
    }
  };
  emitter.on(bus_reply_stream, listener);
  listeners.push(reply);
},
```

**After** (lines 18-24):
```typescript
on_reply_from_extension: (event_name, reply) => {
  const listener = (emitter_data: any) => {
    log.debug(`[bus] received from Extension`, emitter_data);
    if (emitter_data && emitter_data.__request_id && event_name.endsWith(emitter_data.__request_id)) {
      reply(emitter_data);
    }
  };
  emitter.on(bus_reply_stream, listener);
  listeners.push(reply);
},
```

### What Changed

The matching condition was changed from:
```typescript
emitter_data.__event === event_name
```

To:
```typescript
emitter_data.__request_id && event_name.endsWith(emitter_data.__request_id)
```