### PR TITLE
fix: correct Zed MCP server configuration structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,14 +246,15 @@ To use a custom extension port (e.g., 8080), add `"--extension-port", "8080"` to
 {
   /// The name of your MCP server
   "drawio": {
-    "command": {
-      /// The path to the executable
-      "path": "npx",
-      /// The arguments to pass to the executable
-      "args": ["-y","drawio-mcp-server"],
-      /// The environment variables to set for the executable
-      "env": {}
-    }
+	/// The path to the executable
+	"command": "npx",
+	/// The arguments to pass to the executable
+	"args": [
+	  "-y",
+	  "drawio-mcp-server"
+	],
+	/// The environment variables to set for the executable
+    "env": {}
   }
 }
 ```
@@ -266,14 +267,15 @@ To use a custom extension port (e.g., 8080), add `"--extension-port", "8080"` to
 {
   /// The name of your MCP server
   "drawio": {
-    "command": {
-      /// The path to the executable
-      "path": "pnpm",
-      /// The arguments to pass to the executable
-      "args": ["dlx","drawio-mcp-server"],
-      /// The environment variables to set for the executable
-      "env": {}
-    }
+	/// The path to the executable
+	"command": "pnpm",
+	/// The arguments to pass to the executable
+	"args": [
+	  "dlx",
+	  "drawio-mcp-server"
+	],
+	/// The environment variables to set for the executable
+    "env": {}
   }
 }
 ```
@@ -283,16 +285,15 @@ To use a custom extension port (e.g., 8080), add `"--extension-port", "8080"` to
 
 ```json
 {
-  /// The name of your MCP server
   "drawio": {
-    "command": {
-      /// The path to the executable
-      "path": "npx",
-      /// The arguments to pass to the executable
-      "args": ["-y","drawio-mcp-server","--extension-port","8080"],
-      /// The environment variables to set for the executable
-      "env": {}
-    }
+    "command": "npx",
+    "args": [
+      "-y",
+      "drawio-mcp-server",
+      "--extension-port",
+      "8080"
+    ],
+    "env": {}
   }
 }
 ```


### PR DESCRIPTION
## Summary
This PR fixes the configuration for the drawio MCP server in Zed.

## Problem 
The previous configuration used a nested object structure for the command field (containing path, args, and env), which caused Zed to throw a schema validation error: invalid type: map, expected path string.

## Solution 

Flattened the configuration structure according to Zed's requirements:
- Moved args and env to be sibling nodes of command.
- Set command directly to the executable string (npx).

## Verification

- [x] Verified that the MCP server starts correctly in Zed.
- [x] Confirmed the "invalid type" error is resolved.