### PR TITLE
feat: add distroless Docker container

### DIFF
--- a/contributing/Dockerfile
+++ b/contributing/Dockerfile
@@ -1,0 +1,64 @@
+# =============================================================================
+# Draw.io MCP Server — Distroless Container
+# =============================================================================
+# Multi-stage build:
+#   1. deps    — install production dependencies only
+#   2. build   — compile TypeScript
+#   3. runtime — Google distroless (no shell, no package manager, minimal CVEs)
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Stage 1: Install production dependencies
+# ---------------------------------------------------------------------------
+FROM node:22-slim AS deps
+
+WORKDIR /app
+
+# Enable corepack for pnpm
+RUN corepack enable && corepack prepare pnpm@10.8.1 --activate
+
+# Copy only what pnpm needs to resolve dependencies
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+
+# Install production dependencies only — no devDependencies
+RUN pnpm install --frozen-lockfile --prod
+
+# ---------------------------------------------------------------------------
+# Stage 2: Build TypeScript
+# ---------------------------------------------------------------------------
+FROM node:22-slim AS build
+
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@10.8.1 --activate
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
+COPY src/ src/
+
+# Install ALL dependencies (including devDependencies for tsc)
+RUN pnpm install --frozen-lockfile
+
+# Compile TypeScript → build/
+RUN pnpm run build
+
+# ---------------------------------------------------------------------------
+# Stage 3: Distroless runtime — nothing but Node.js and our code
+# ---------------------------------------------------------------------------
+FROM gcr.io/distroless/nodejs22-debian12 AS runtime
+
+WORKDIR /app
+
+# Production node_modules from stage 1
+COPY --from=deps /app/node_modules ./node_modules
+
+# Compiled JavaScript from stage 2
+COPY --from=build /app/build ./build
+
+# package.json needed for ESM module resolution ("type": "module")
+COPY package.json ./
+
+# WebSocket extension port + HTTP transport port
+EXPOSE 3333 3000
+
+# Distroless has no shell — CMD is passed directly to the Node.js entrypoint
+CMD ["build/index.js"]


### PR DESCRIPTION
## Summary

- Adds a multi-stage Dockerfile in `contributing/` using Google's [distroless](https://github.com/GoogleContainerTools/distroless) `nodejs22-debian12` base image
- Minimizes attack surface: no shell, no package manager, no OS utilities in the final image
- Final image size: **174 MB**

## How it works

The Dockerfile uses a **3-stage build**:

| Stage | Base | Purpose |
|-------|------|---------|
| `deps` | `node:22-slim` | Install **production** dependencies only (`pnpm install --prod`) |
| `build` | `node:22-slim` | Install all dependencies + compile TypeScript (`pnpm run build`) |
| `runtime` | `gcr.io/distroless/nodejs22-debian12` | Final image — only compiled JS, prod `node_modules`, and `package.json` |

The distroless base image contains **only** the Node.js runtime and minimal system libraries. There is no shell (`/bin/sh`), no package manager, no `curl`, no `apt` — nothing an attacker could use for lateral movement.

### Build & run

```bash
# Build
docker build -f contributing/Dockerfile -t drawio-mcp-server:distroless .

# Run with HTTP transport
docker run -p 3000:3000 -p 3333:3333 drawio-mcp-server:distroless build/index.js --transport http

# Run with stdio transport (default)
docker run -i drawio-mcp-server:distroless
```

### Ports

| Port | Protocol | Purpose |
|------|----------|---------|
| 3333 | WebSocket | Browser extension connection |
| 3000 | HTTP | Streamable HTTP MCP transport |

## Test plan

- [x] Image builds successfully (0 errors)
- [x] Container starts, server initializes
- [x] `GET /health` returns `{"status": "ok"}`
- [x] MCP `initialize` handshake completes (protocol `2025-03-26`)
- [x] MCP `tools/list` returns all 18 tools
- [x] MCP `tools/call` correctly dispatches to WebSocket bus (verified via logs — times out as expected without a connected Draw.io instance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)