### PR TITLE
refactor(plugin): bootstrap follow-up — URL config unification, debug log, docs

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -394,6 +394,8 @@ Override the directory with `--tls-dir` or `DRAWIO_MCP_TLS_DIR` (e.g. for Docker
 On the first auto-mode run the server prints the OS-specific command to install `ca.crt` into your trust store. Without this, browsers will refuse the WSS connection (the browser extension will appear silently disconnected). Quick reference:
 
 - **Linux (Debian/Ubuntu):** `sudo cp <ca.crt> /usr/local/share/ca-certificates/drawio-mcp-ca.crt && sudo update-ca-certificates`
+- **Linux (Fedora/RHEL):** `sudo cp <ca.crt> /etc/pki/ca-trust/source/anchors/drawio-mcp-ca.crt && sudo update-ca-trust extract`
+- **Linux (Arch/Manjaro):** `sudo trust anchor --store <ca.crt>`
 - **macOS:** `sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain <ca.crt>`
 - **Windows (admin):** `certutil -addstore -f ROOT <ca.crt>`
 - **Firefox:** uses its own NSS store — import via Settings → Privacy & Security → Certificates → Authorities → Import

--- a/packages/drawio-mcp-extension/entrypoints/main_world-plugin.ts
+++ b/packages/drawio-mcp-extension/entrypoints/main_world-plugin.ts
@@ -59,7 +59,7 @@ const initializeSettingsDialog = (): void => {
     connectionState,
     isSaving: false,
     formData: {
-      port: config.websocketPort.toString(),
+      url: config.websocketUrl ?? "",
     },
     errors: {},
   };
@@ -123,7 +123,7 @@ const showSettings = (): void => {
       connectionState,
       isSaving: false,
       formData: {
-        port: config.websocketPort.toString(),
+        url: config.websocketUrl ?? "",
       },
       errors: {},
     });

--- a/packages/drawio-mcp-extension/entrypoints/options/Options.tsx
+++ b/packages/drawio-mcp-extension/entrypoints/options/Options.tsx
@@ -1,13 +1,14 @@
 import { useState, useEffect, useMemo } from "react";
-import { getConfig, saveConfig, resetConfigToDefaults, isValidExtensionWebSocketUrl, type ExtensionConfig } from "../../config";
+import { getConfig, saveConfig, resetConfigToDefaults, isValidExtensionWebSocketUrl, DEFAULT_CONFIG, type ExtensionConfig } from "../../config";
 import { validateMV3Pattern, isValidPatternList, deduplicatePatterns, patternsAreEquivalent } from "../../utils/urlPatternValidator";
 
+const DEFAULT_WS_URL = `ws://localhost:${DEFAULT_CONFIG.websocketPort}`;
+
 function Options() {
-  const [config, setConfig] = useState<ExtensionConfig>({ websocketPort: 3333, urlPatterns: ["*://app.diagrams.net/*"], injectIntoIframes: false });
+  const [config, setConfig] = useState<ExtensionConfig>({ websocketPort: DEFAULT_CONFIG.websocketPort, urlPatterns: ["*://app.diagrams.net/*"], injectIntoIframes: false });
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error', text: string } | null>(null);
-  const [portInput, setPortInput] = useState('');
   const [urlInput, setUrlInput] = useState('');
   const [urlError, setUrlError] = useState<string>('');
   const [patterns, setPatterns] = useState<string[]>([]);
@@ -24,7 +25,6 @@ function Options() {
     try {
       const currentConfig = await getConfig();
       setConfig(currentConfig);
-      setPortInput(currentConfig.websocketPort.toString());
       setUrlInput(currentConfig.websocketUrl ?? '');
       setPatterns(currentConfig.urlPatterns);
       setInjectIntoIframes(currentConfig.injectIntoIframes);
@@ -36,24 +36,7 @@ function Options() {
     }
   };
 
-  const validatePort = (port: string): { isValid: boolean; error?: string } => {
-    const portNum = parseInt(port, 10);
-    if (isNaN(portNum)) {
-      return { isValid: false, error: 'Port must be a number' };
-    }
-    if (portNum < 1024 || portNum > 65535) {
-      return { isValid: false, error: 'Port must be between 1024 and 65535' };
-    }
-    return { isValid: true };
-  };
-
   const handleSave = async () => {
-    const validation = validatePort(portInput);
-    if (!validation.isValid) {
-      setMessage({ type: 'error', text: validation.error || 'Invalid port' });
-      return;
-    }
-
     const trimmedUrl = urlInput.trim();
     if (trimmedUrl.length > 0 && !isValidExtensionWebSocketUrl(trimmedUrl)) {
       setUrlError('URL must start with ws:// or wss://');
@@ -72,7 +55,7 @@ function Options() {
     try {
       const uniquePatterns = deduplicatePatterns(patterns);
       const newConfig: ExtensionConfig = {
-        websocketPort: parseInt(portInput, 10),
+        websocketPort: config.websocketPort,
         urlPatterns: uniquePatterns,
         websocketUrl: trimmedUrl.length > 0 ? trimmedUrl : undefined,
         injectIntoIframes
@@ -95,7 +78,6 @@ function Options() {
       await resetConfigToDefaults();
       const defaultConfig = await getConfig(); // Reload from defaults
       setConfig(defaultConfig);
-      setPortInput(defaultConfig.websocketPort.toString());
       setUrlInput(defaultConfig.websocketUrl ?? '');
       setUrlError('');
       setPatterns(defaultConfig.urlPatterns);
@@ -154,13 +136,6 @@ function Options() {
       ...validateMV3Pattern(pattern)
     })), [patterns]);
 
-  const handleInputChange = (value: string) => {
-    setPortInput(value);
-    if (message) {
-      setMessage(null);
-    }
-  };
-
   if (loading) {
     return (
       <div className="options-container">
@@ -187,24 +162,7 @@ function Options() {
             <h3>WebSocket Server Configuration</h3>
 
             <div className="form-group">
-              <label htmlFor="port-input">Port Number:</label>
-              <input
-                id="port-input"
-                type="number"
-                value={portInput}
-                onChange={(e) => handleInputChange(e.target.value)}
-                min={1024}
-                max={65535}
-                className="port-input"
-                disabled={saving}
-                placeholder="3333"
-                required
-              />
-              <span className="input-hint">(1024-65535)</span>
-            </div>
-
-            <div className="form-group">
-              <label htmlFor="url-input">Custom WebSocket URL (optional):</label>
+              <label htmlFor="url-input">WebSocket URL:</label>
               <input
                 id="url-input"
                 type="text"
@@ -216,9 +174,12 @@ function Options() {
                 }}
                 className="port-input"
                 disabled={saving}
-                placeholder="wss://example.com/drawio-ws"
+                placeholder={DEFAULT_WS_URL}
               />
-              <span className="input-hint">Overrides host/port. Use wss:// behind HTTPS proxies.</span>
+              <span className="input-hint">
+                Leave blank to use the default ({DEFAULT_WS_URL}). Must start with ws:// or wss://.
+                Use wss:// when the MCP server sits behind an HTTPS reverse proxy.
+              </span>
               {urlError && <span className="error-text">{urlError}</span>}
             </div>
           </div>

--- a/packages/drawio-mcp-extension/entrypoints/popup/App.css
+++ b/packages/drawio-mcp-extension/entrypoints/popup/App.css
@@ -45,6 +45,12 @@
   color: #888;
 }
 
+.connection-url {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85em;
+  word-break: break-all;
+}
+
 /* Connection status styles */
 .connection-status {
   display: flex;

--- a/packages/drawio-mcp-extension/entrypoints/popup/App.tsx
+++ b/packages/drawio-mcp-extension/entrypoints/popup/App.tsx
@@ -1,19 +1,19 @@
 import { useState, useEffect } from "react";
 import "./App.css";
-import { getConfig } from "../../config";
+import { getWebSocketUrl } from "../../config";
 
 type ConnectionState = "connected" | "connecting" | "disconnected";
 
 function App() {
   const [connectionState, setConnectionState] = useState<ConnectionState>("disconnected");
   const [featuresExpanded, setFeaturesExpanded] = useState(false);
-  const [currentPort, setCurrentPort] = useState<number>(3333);
+  const [currentUrl, setCurrentUrl] = useState<string>("");
 
   useEffect(() => {
-    // Load current configuration
-    getConfig().then(config => {
-      setCurrentPort(config.websocketPort);
-    }).catch(error => console.error("Error loading config:", error));
+    // Load current effective WebSocket URL (override or derived default)
+    getWebSocketUrl()
+      .then(setCurrentUrl)
+      .catch(error => console.error("Error loading config:", error));
 
     // Request connection state from background script when popup opens
     browser.runtime.sendMessage({ type: "GET_CONNECTION_STATE" })
@@ -65,7 +65,14 @@ function App() {
       </div>
       <div className="card">
         <p>
-          The WebSocket connection is currently <strong>{connectionState}</strong> on port <strong>{currentPort}</strong>.
+          The WebSocket connection is currently <strong>{connectionState}</strong>
+          {currentUrl && (
+            <>
+              {" at "}
+              <strong className="connection-url">{currentUrl}</strong>
+            </>
+          )}
+          .
         </p>
         {connectionState !== "connected" && (
           <p>

--- a/packages/drawio-mcp-plugin/src/bootstrap.ts
+++ b/packages/drawio-mcp-plugin/src/bootstrap.ts
@@ -210,6 +210,7 @@ export function bootstrapPlugin(opts: BootstrapOptions): BootstrapHandle {
       def.name,
       buildToolHandler(def.name, def.params, def.handler),
     );
+    console.debug(`[plugin] registered tool ${def.name}`);
   });
 
   transport.onMessage((message: any) => {

--- a/packages/drawio-mcp-plugin/src/plugin.ts
+++ b/packages/drawio-mcp-plugin/src/plugin.ts
@@ -71,7 +71,7 @@ const initializeSettingsDialog = (): void => {
     connectionState,
     isSaving: false,
     formData: {
-      port: config.websocketPort.toString(),
+      url: config.websocketUrl ?? "",
     },
     errors: {},
   };
@@ -135,7 +135,7 @@ const showSettings = (): void => {
       connectionState,
       isSaving: false,
       formData: {
-        port: config.websocketPort.toString(),
+        url: config.websocketUrl ?? "",
       },
       errors: {},
     });

--- a/packages/drawio-mcp-plugin/src/pluginConfig.ts
+++ b/packages/drawio-mcp-plugin/src/pluginConfig.ts
@@ -16,7 +16,7 @@ export const DEFAULT_PLUGIN_CONFIG: PluginConfig = {
   serverUrl: "",
 };
 
-function isValidWebSocketUrl(value: unknown): value is string {
+export function isValidWebSocketUrl(value: unknown): value is string {
   if (typeof value !== "string" || value.length === 0) {
     return false;
   }

--- a/packages/drawio-mcp-plugin/src/settingsDialog.ts
+++ b/packages/drawio-mcp-plugin/src/settingsDialog.ts
@@ -5,18 +5,21 @@
  * Creates plain DOM modal dialog for Draw.io integration
  */
 
-import type { WebSocketManager } from "./websocketManager";
-import type { PluginConfig } from "./pluginConfig";
+import {
+  buildWebSocketUrl,
+  isValidWebSocketUrl,
+  type PluginConfig,
+} from "./pluginConfig";
 
 export interface SettingsDialogState {
   config: PluginConfig;
   connectionState: "connecting" | "connected" | "disconnected";
   isSaving: boolean;
   formData: {
-    port: string;
+    url: string;
   };
   errors: {
-    port?: string;
+    url?: string;
   };
 }
 
@@ -28,7 +31,7 @@ export type SettingsMessage =
       type: "UPDATE_CONNECTION_STATE";
       state: "connecting" | "connected" | "disconnected";
     }
-  | { type: "UPDATE_PORT"; port: string }
+  | { type: "UPDATE_URL"; url: string }
   | { type: "SAVE" }
   | { type: "RESET" };
 
@@ -37,6 +40,14 @@ export interface SettingsDialogActions {
   onClose: () => void;
   onPing: () => Promise<boolean>;
   onReconnect: () => void;
+}
+
+function defaultUrlFor(config: PluginConfig): string {
+  return buildWebSocketUrl({ ...config, websocketUrl: undefined });
+}
+
+function effectiveUrlFor(config: PluginConfig): string {
+  return buildWebSocketUrl(config);
 }
 
 function createDialogContainer(): HTMLElement {
@@ -133,10 +144,7 @@ function createDialogHeader(title: string, onClose: () => void): HTMLElement {
   return header;
 }
 
-function createDialogBody(
-  state: SettingsDialogState,
-  actions: SettingsDialogActions,
-): HTMLElement {
+function createDialogBody(state: SettingsDialogState): HTMLElement {
   const body = document.createElement("div");
   body.className = "dialog-body";
   body.style.cssText = `
@@ -146,7 +154,7 @@ function createDialogBody(
   const statusSection = createStatusSection(state);
   body.appendChild(statusSection);
 
-  const formSection = createFormSection(state, actions);
+  const formSection = createFormSection(state);
   body.appendChild(formSection);
 
   return body;
@@ -209,36 +217,34 @@ function createStatusSection(state: SettingsDialogState): HTMLElement {
   statusIndicator.appendChild(indicator);
   statusIndicator.appendChild(statusText);
 
-  const portDisplay = document.createElement("div");
-  portDisplay.style.cssText = `
+  const urlDisplay = document.createElement("div");
+  urlDisplay.style.cssText = `
     font-size: 14px;
     color: #666;
+    word-break: break-all;
   `;
-  portDisplay.textContent = `Port: ${state.config.websocketPort}`;
+  urlDisplay.textContent = `URL: ${effectiveUrlFor(state.config)}`;
 
   section.appendChild(title);
   section.appendChild(statusIndicator);
-  section.appendChild(portDisplay);
+  section.appendChild(urlDisplay);
 
   return section;
 }
 
-function createFormSection(
-  state: SettingsDialogState,
-  actions: SettingsDialogActions,
-): HTMLElement {
+function createFormSection(state: SettingsDialogState): HTMLElement {
   const section = document.createElement("div");
   section.className = "form-section";
 
-  const portGroup = document.createElement("div");
-  portGroup.className = "form-group";
-  portGroup.style.cssText = `
+  const urlGroup = document.createElement("div");
+  urlGroup.className = "form-group";
+  urlGroup.style.cssText = `
     margin-bottom: 16px;
   `;
 
   const label = document.createElement("label");
-  label.textContent = "WebSocket Port";
-  label.htmlFor = "mcp-port-input";
+  label.textContent = "WebSocket URL";
+  label.htmlFor = "mcp-url-input";
   label.style.cssText = `
     display: block;
     margin-bottom: 6px;
@@ -247,21 +253,23 @@ function createFormSection(
   `;
 
   const input = document.createElement("input");
-  input.id = "mcp-port-input";
-  input.type = "number";
-  input.min = "1024";
-  input.max = "65535";
-  input.value = state.formData.port;
+  input.id = "mcp-url-input";
+  input.type = "text";
+  input.spellcheck = false;
+  input.autocomplete = "off";
+  input.value = state.formData.url;
+  input.placeholder = defaultUrlFor(state.config);
   input.style.cssText = `
     width: 100%;
     padding: 8px 12px;
     border: 1px solid #ddd;
     border-radius: 4px;
     font-size: 14px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     box-sizing: border-box;
   `;
 
-  if (state.errors.port) {
+  if (state.errors.url) {
     input.style.borderColor = "#dc3545";
   }
 
@@ -269,43 +277,41 @@ function createFormSection(
     const value = (e.target as HTMLInputElement).value;
     window.dispatchEvent(
       new CustomEvent("mcp-settings-message", {
-        detail: { type: "UPDATE_PORT", port: value },
+        detail: { type: "UPDATE_URL", url: value },
       }),
     );
   });
 
   const hint = document.createElement("div");
-  hint.textContent = "Port must be between 1024 and 65535";
+  hint.textContent = `Leave blank to use the default (${defaultUrlFor(state.config)}). Must start with ws:// or wss://`;
   hint.style.cssText = `
     font-size: 12px;
     color: #666;
     margin-top: 4px;
+    word-break: break-all;
   `;
 
-  if (state.errors.port) {
+  urlGroup.appendChild(label);
+  urlGroup.appendChild(input);
+  urlGroup.appendChild(hint);
+
+  if (state.errors.url) {
     const error = document.createElement("div");
-    error.textContent = state.errors.port;
+    error.textContent = state.errors.url;
     error.style.cssText = `
       font-size: 12px;
       color: #dc3545;
       margin-top: 4px;
     `;
-    portGroup.appendChild(error);
+    urlGroup.appendChild(error);
   }
 
-  portGroup.appendChild(label);
-  portGroup.appendChild(input);
-  portGroup.appendChild(hint);
-
-  section.appendChild(portGroup);
+  section.appendChild(urlGroup);
 
   return section;
 }
 
-function createDialogFooter(
-  state: SettingsDialogState,
-  actions: SettingsDialogActions,
-): HTMLElement {
+function createDialogFooter(state: SettingsDialogState): HTMLElement {
   const footer = document.createElement("div");
   footer.className = "dialog-footer";
   footer.style.cssText = `
@@ -458,8 +464,8 @@ export function createSettingsDialog(
     const content = createDialogContent();
 
     const header = createDialogHeader("MCP Settings", () => actions.onClose());
-    const body = createDialogBody(currentState, actions);
-    const footer = createDialogFooter(currentState, actions);
+    const body = createDialogBody(currentState);
+    const footer = createDialogFooter(currentState);
 
     content.appendChild(header);
     content.appendChild(body);
@@ -482,9 +488,9 @@ export function createSettingsDialog(
       const message = event.detail;
 
       switch (message.type) {
-        case "UPDATE_PORT":
-          currentState.formData.port = message.port;
-          delete currentState.errors.port;
+        case "UPDATE_URL":
+          currentState.formData.url = message.url;
+          delete currentState.errors.url;
           break;
 
         case "SAVE":
@@ -524,15 +530,10 @@ export function createSettingsDialog(
   };
 
   const validateAndSave = (): boolean => {
-    const portNum = parseInt(currentState.formData.port, 10);
+    const trimmed = currentState.formData.url.trim();
 
-    if (isNaN(portNum)) {
-      currentState.errors.port = "Port must be a number";
-      return false;
-    }
-
-    if (portNum < 1024 || portNum > 65535) {
-      currentState.errors.port = "Port must be between 1024 and 65535";
+    if (trimmed.length > 0 && !isValidWebSocketUrl(trimmed)) {
+      currentState.errors.url = "URL must start with ws:// or wss://";
       return false;
     }
 
@@ -540,8 +541,8 @@ export function createSettingsDialog(
     currentState.isSaving = true;
 
     const newConfig: PluginConfig = {
-      websocketPort: portNum,
-      serverUrl: currentState.config.serverUrl,
+      ...currentState.config,
+      websocketUrl: trimmed.length > 0 ? trimmed : undefined,
     };
 
     actions.onSave(newConfig);

--- a/packages/drawio-mcp-server/src/index.ts
+++ b/packages/drawio-mcp-server/src/index.ts
@@ -181,13 +181,14 @@ function registerConfigRoute(
   config: ServerConfig,
   scheme: "http" | "https",
 ) {
-  app.get("/api/config", (c) =>
-    c.json({
-      websocketPort: config.extensionPort,
-      serverUrl: `${scheme}://localhost:${config.httpPort}`,
-      websocketUrl: config.webSocketUrl,
-    }),
-  );
+  app.get("/api/config", (c) => {
+    const serverUrl = `${scheme}://localhost:${config.httpPort}`;
+    return c.json(
+      config.webSocketUrl
+        ? { serverUrl, websocketUrl: config.webSocketUrl }
+        : { serverUrl, websocketPort: config.extensionPort },
+    );
+  });
 }
 
 function registerEditorRoutes(app: Hono, config: ServerConfig, log: AppLogger) {


### PR DESCRIPTION
## Summary
Recovery PR. Four follow-up commits to PR #52 never reached the remote (pushes silently failed during the original branch's lifecycle), so only the bootstrap-extraction commit was merged. Re-applies them on top of current main:

1. **`refactor(plugin): debug-log each tool registration in bootstrap`** — restores per-tool \`[plugin] registered tool <name>\` debug log that the old \`bus.ts\` printed; now in shared bootstrap so all three entrypoints get it.
2. **`feat(config): unify WebSocket URL config to single override`** — server \`/api/config\` emits \`websocketPort\` and \`websocketUrl\` as mutually exclusive; in-page Editor settings dialog collapses to one URL field; extension popup shows live effective URL. Also fixes silent dropping of operator \`websocketUrl\` on user save.
3. **`feat(extension-options): collapse port + URL fields to single URL input`** — Options page mirrors the Editor dialog: one URL input, blank=default, validates ws://wss://. Port input removed.
4. **`docs(tls): add Fedora/RHEL and Arch/Manjaro CA install commands`** — CONFIG.md trust-store reference now matches the runtime install hint (was missing the two RPM/Arch lines).

## Test plan
- [x] \`pnpm -r build\` — clean
- [x] \`pnpm -r test\` — 309/309 pass
- [ ] Manual: editor settings dialog + extension popup show URL; Options page accepts/rejects URLs as expected