### PR TITLE
fix(register-tool): strip $schema at tools/list response time

### DIFF
--- a/packages/drawio-mcp-server/src/register-tool.ts
+++ b/packages/drawio-mcp-server/src/register-tool.ts
@@ -2,43 +2,97 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { stripSchemaRecursively } from "./strip-schema.js";
 
 /**
- * Creates a wrapped version of McpServer.tool that automatically strips
- * `$schema` from the inputSchema after tool registration.
+ * Wraps an `McpServer` so that the `tools/list` response strips the
+ * `$schema` key from every tool's `inputSchema` and `outputSchema`.
  *
- * The `$schema` key injected by zodToJsonSchema causes Claude Code to silently
- * drop tools because the `$` character fails Anthropic's validation regex
- * `^[a-zA-Z0-9_.-]{1,64}$`.
+ * Why this is necessary:
  *
- * @param server - The McpServer instance to wrap
- * @returns The same server instance, but with a modified tool() method
+ * - The MCP SDK lazily serializes tool schemas: it stores the Zod object
+ *   verbatim at registration time and only converts to JSON Schema
+ *   (via `zodToJsonSchema` / `z4mini.toJSONSchema`) when a client issues
+ *   `tools/list`. The conversion emits a top-level
+ *   `"$schema": "http://json-schema.org/draft-07/schema#"` field.
+ *
+ * - Claude Code's MCP ingest layer can't tolerate the `$` character in
+ *   schema keys (Anthropic's parameter-name regex is
+ *   `^[a-zA-Z0-9_.-]{1,64}$`). When `$schema` is present, the entire
+ *   `properties` object is dropped, leaving tools effectively schemaless.
+ *   The user can see the tool name but the LLM has no way to know which
+ *   arguments to send, so calls fail at runtime.
+ *
+ * - A previous attempt at this fix tried to strip `$schema` from the
+ *   stored `_registeredTools[name].inputSchema` via `setTimeout(0)`.
+ *   That was a no-op against modern SDKs because the stored value at
+ *   that point is the raw Zod object (which doesn't have `$schema`).
+ *   The `$schema` key is added by `toJsonSchemaCompat` at serialization
+ *   time, not at registration time.
+ *
+ * The fix here intercepts the `tools/list` request handler that the SDK
+ * registers internally on the first `server.tool(...)` call, and wraps
+ * it so the response runs through `stripSchemaRecursively` before being
+ * returned to the client.
  */
 export function createServerWithSchemaStripping(server: McpServer): McpServer {
-  // Store original tool method
   const originalTool = server.tool.bind(server);
+  let patched = false;
 
-  // Override tool method
-  server.tool = function tool(
-    name: string,
-    description: string,
-    inputSchema: Record<string, any>,
-    handler: any,
-  ) {
-    // Call original tool method
-    const result = originalTool(name, description, inputSchema, handler);
-
-    // Strip $schema from the registered tool's inputSchema
-    // This must be done after registration
-    setTimeout(() => {
-      const registeredTool = (server as any)._registeredTools?.[name];
-      if (registeredTool?.inputSchema) {
-        registeredTool.inputSchema = stripSchemaRecursively(
-          registeredTool.inputSchema,
-        );
-      }
-    }, 0);
-
+  server.tool = function tool(...args: Parameters<typeof originalTool>) {
+    const result = originalTool(...args);
+    // The SDK lazily registers the tools/list handler on the first
+    // server.tool() call (via setToolRequestHandlers). After that call
+    // returns, the handler is in place and we can wrap it.
+    if (!patched) {
+      patched = true;
+      patchToolsListHandler(server);
+    }
     return result;
   } as typeof originalTool;
 
   return server;
+}
+
+function patchToolsListHandler(server: McpServer): void {
+  // The McpServer wraps an inner Server (the low-level protocol layer).
+  // Its `_requestHandlers` Map stores per-method handlers keyed by the
+  // method name literal (e.g. "tools/list").
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const innerServer = (server as any).server;
+  const handlers: Map<string, (...args: unknown[]) => unknown> | undefined =
+    innerServer?._requestHandlers;
+  if (!handlers) {
+    // SDK internals changed; fail closed (no-op) so we don't crash the
+    // server. The tools will still work but schemas will leak `$schema`.
+    return;
+  }
+
+  const original = handlers.get("tools/list");
+  if (!original) {
+    return;
+  }
+
+  handlers.set("tools/list", async (...callArgs: unknown[]) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const response: any = await original(...callArgs);
+    if (response && Array.isArray(response.tools)) {
+      response.tools = response.tools.map(stripToolSchemas);
+    }
+    return response;
+  });
+}
+
+interface ToolDefinition {
+  inputSchema?: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+function stripToolSchemas(tool: ToolDefinition): ToolDefinition {
+  const next: ToolDefinition = { ...tool };
+  if (next.inputSchema) {
+    next.inputSchema = stripSchemaRecursively(next.inputSchema);
+  }
+  if (next.outputSchema) {
+    next.outputSchema = stripSchemaRecursively(next.outputSchema);
+  }
+  return next;
 }


### PR DESCRIPTION
## Summary

The existing `setTimeout`-based `$schema` stripper in
`createServerWithSchemaStripping` is a no-op against the current MCP SDK
(`@modelcontextprotocol/sdk@1.29.0` + `zod@4.2.1`). As a result, Claude
Code sees `$schema` in every tool's `inputSchema`, fails its
parameter-name validation (`^[a-zA-Z0-9_.-]{1,64}$`), and wipes the
entire `properties` object — leaving tools effectively schemaless from
the LLM's perspective.

The user can see the tool name but the model has no schema to drive
arguments from, so it sends untyped values that the server then rejects
with `Invalid input: expected object, received string` at runtime.

## Root cause

The SDK now stores Zod schemas verbatim at registration time in
`_registeredTools[name].inputSchema` and only serializes to JSON Schema
when a client issues `tools/list`. The `$schema` key is injected by
`z4mini.toJSONSchema` at *serialization* time — not registration. So the
`setTimeout(0)` that mutates the stored Zod object never sees `$schema`
to strip.

Concretely, today's flow:

1. `server.tool(...)` stores the **Zod object** at `_registeredTools[name].inputSchema`.
2. `setTimeout(0)` fires → `stripSchemaRecursively(zodObject)` → no-op (Zod has no `$schema`).
3. Client calls `tools/list` → SDK runs `toJsonSchemaCompat(zodObject)` → emits JSON Schema **with** `$schema`.
4. Claude Code receives the schema with `$schema`, sanitizes, wipes `properties`.

## Fix

Intercept the inner `Server._requestHandlers` map entry for `"tools/list"`
after the SDK has registered it (lazily, on first `server.tool(...)`
call). The wrapper delegates to the original handler and post-processes
each tool's `inputSchema` and `outputSchema` through the existing
`stripSchemaRecursively` — so the SDK still owns serialization and we
only post-process its output.

No public API change: same `createServerWithSchemaStripping(server)`
signature, same call site in `src/index.ts`.

## Reproducer

Before this patch, against any running drawio-mcp-server (HTTP transport):

```sh
SID=$(uuidgen)
curl -s "$MCP_URL" -X POST \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -H "Mcp-Session-Id: $SID" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"r","version":"0.1"}}}' >/dev/null

curl -s "$MCP_URL" -X POST \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -H "Mcp-Session-Id: $SID" \
  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
  | sed 's/^event: message//; s/^data: //' \
  | jq '.result.tools[] | select(.name=="add-rectangle").inputSchema | {has_schema: has("$schema"), props_count: (.properties|length)}'
```

Before: `{"has_schema": true, "props_count": 9}` (Claude Code wipes
this to `{type:"object", properties:{}}` on its side).
After: `{"has_schema": false, "props_count": 9}` (Claude Code passes
through unchanged).

## Verification

- `pnpm --filter drawio-mcp-server run build` — clean.
- `pnpm --filter drawio-mcp-server run test` — **309 / 309 passing**.
- Local server probe (above curl) → `$schema` gone, all properties present.
- End-to-end: Claude Code's MCP tool wrapper now sees the full schema
  for `add-rectangle` and routes object arguments correctly to
  `target_page`, instead of coercing them to strings.

## Notes

- This fix only changes how the existing `stripSchemaRecursively` is
  *invoked*. The strip itself is unchanged.
- If a future SDK version changes the inner `_requestHandlers` shape,
  `patchToolsListHandler` fails closed (no-op) — server still works,
  just with `$schema` leaking again. The TODO is to swap to a public
  SDK API for response post-processing if/when one exists.

## Test plan

- [x] All existing unit/integration tests still pass (309/309).
- [x] `tools/list` no longer emits `$schema` (verified by curl + jq).
- [x] Claude Code sees the full `inputSchema.properties` for `add-rectangle`
      and correctly routes `target_page` as an object argument.
- [ ] (Optional, maintainer's choice) add a regression test that asserts
      `$schema` is absent from `tools/list` responses.