### PR TITLE
fix(docker): copy all workspace packages and build compat, dev-proxy, plugin before server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,7 @@ WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@10.8.1 --activate
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-COPY packages/drawio-mcp-plugin ./packages/drawio-mcp-plugin
-COPY packages/drawio-mcp-server ./packages/drawio-mcp-server
+COPY packages ./packages
 
 RUN pnpm install --frozen-lockfile
 
@@ -32,12 +31,18 @@ WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@10.8.1 --activate
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
-COPY packages/drawio-mcp-plugin ./packages/drawio-mcp-plugin
-COPY packages/drawio-mcp-server ./packages/drawio-mcp-server
+COPY packages ./packages
 
 RUN pnpm install --frozen-lockfile
 
-RUN pnpm --filter drawio-mcp-server run build
+# Build order matters: the server's `vendor:compat` step copies
+# ../drawio-mcp-compat/src, its build copies the bundled plugin from
+# node_modules/drawio-mcp-plugin/dist, and tsc type-checks
+# src/real-environment/, which imports drawio-mcp-dev-proxy.
+RUN pnpm --filter drawio-mcp-compat run build \
+ && pnpm --filter drawio-mcp-dev-proxy run build \
+ && pnpm --filter drawio-mcp-plugin run build \
+ && pnpm --filter drawio-mcp-server run build
 
 # ---------------------------------------------------------------------------
 # Stage 3: Runtime — install production deps and run
@@ -49,6 +54,11 @@ WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@10.8.1 --activate
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+# Runtime needs only these packages: compat is vendored into the server
+# build and the plugin bundle is baked into build/plugin/. dev-proxy and
+# extension have postinstall hooks (caddy download, `wxt prepare`) that
+# fail or add bloat under --prod.
+COPY packages/drawio-mcp-compat ./packages/drawio-mcp-compat
 COPY packages/drawio-mcp-plugin ./packages/drawio-mcp-plugin
 COPY packages/drawio-mcp-server ./packages/drawio-mcp-server
 


### PR DESCRIPTION
## Summary

`docker build` fails on current main — the Dockerfile predates the `drawio-mcp-compat` / `drawio-mcp-dev-proxy` package split (flagged in https://github.com/lgazo/drawio-mcp-server/issues/56#issuecomment-4946015638). Three failures in sequence:

1. `pnpm --filter drawio-mcp-server run build` runs `vendor:compat`, which does `cp ../drawio-mcp-compat/src/index.ts …` — but `packages/drawio-mcp-compat` is never copied into the image.
2. `tsc` type-checks `src/real-environment/harness.ts`, which imports `drawio-mcp-dev-proxy` — not copied either, and its `types` entry points at its `build/` output, so it must also be *built* first.
3. The server build step copies `node_modules/drawio-mcp-plugin/dist/mcp-plugin.js`, which only exists after the plugin package is built — nothing builds it.

## Fix

- **deps + build stages**: `COPY packages ./packages` (all workspace packages) instead of the hardcoded two.
- **build stage**: build `compat → dev-proxy → plugin → server` in order — mirrors what 3af0d75 did for the CI package/publish flows.
- **runtime stage**: keeps an explicit package list (`compat`, `plugin`, `server`), now including `compat` since the plugin declares it as a prod dependency. `dev-proxy` and `extension` are deliberately excluded: their postinstall hooks (`install-caddy.mjs` downloads a 39 MB caddy binary; `wxt prepare` fails because wxt is a devDependency absent under `--prod`) break or bloat the production install, and neither is a runtime dependency — compat is vendored into the server build and the plugin bundle is baked into `build/plugin/`.

## Tested

`docker build` from a clean checkout of main + this patch succeeds; the resulting image runs and serves correctly. It is instruction-identical to the image behind the #56 verification: HTTP transport + `--editor`, bulk `import-diagram` replace / `new-page` over the WebSocket bus, schema-intact `tools/list` (28 tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)