### PR TITLE
feat: add document title and save tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Let's do some Vibe Diagramming with the most wide-spread diagramming tool called
 - Multi-page targeting with required `target_page` selectors for page-scoped tools ![v2.1.0](https://img.shields.io/badge/v2.1.0-blue)
 - Per-document FIFO serialization for live operations, so multiple agents can work on different files safely ![v2.1.0](https://img.shields.io/badge/v2.1.0-blue)
 - Page management tools: `list-pages`, `get-current-page`, `create-page`, `copy-page`, `rename-page` ![v2.1.0](https://img.shields.io/badge/v2.1.0-blue)
+- Document persistence tools: `set-document-title` and `save-document`
 - Import, embed, or expand [Mermaid](https://mermaid.js.org/) diagrams ![v2.1.0](https://img.shields.io/badge/v2.1.0-blue)
 - Firefox support is back, TLS mode is necessary ![v2.1.0](https://img.shields.io/badge/v2.1.0-blue)
 - Server supports TLS mode and optionally generates self-signed certificates ![v2.1.0](https://img.shields.io/badge/v2.1.0-blue)

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -51,6 +51,23 @@ Lists all currently connected Draw.io document instances.
 
 *Returns*: Array of document objects with `id`, `title`, `mode`, `hash`, `file_url`, `page_count`, and `current_page`
 
+### `set-document-title`
+
+Renames the selected Draw.io document through its active storage provider. When the new title omits an extension, the current `.drawio`, `.drawio.svg`, `.drawio.png`, `.xml`, `.svg`, or `.png` suffix is preserved.
+
+*Parameters*:
+- `title`: New document title, with or without the existing extension
+
+*Returns*: The previous and resulting document titles
+
+### `save-document`
+
+Triggers Draw.io's existing **File → Save** action for the selected document, preserving the editor's current storage mode.
+
+The call confirms that the save flow was triggered. Authentication, conflict, permission, or **Save As** prompts may still require user interaction in the Draw.io tab.
+
+*Returns*: Trigger status plus the current document title and storage mode
+
 ## Diagram Inspection Tools
 
 ### `get-selected-cell`

--- a/packages/drawio-mcp-plugin/src/tool-registry.ts
+++ b/packages/drawio-mcp-plugin/src/tool-registry.ts
@@ -33,6 +33,8 @@ import {
   type DrawioCellOptions,
 } from "./drawio-tools.js";
 import { import_mermaid } from "./tools/import-mermaid/index.js";
+import { save_document } from "./tools/save-document/index.js";
+import { set_document_title } from "./tools/set-document-title/index.js";
 
 export type ToolDefinition = {
   name: string;
@@ -394,6 +396,16 @@ const rawToolDefinitions: ToolDefinition[] = [
     name: "rename-page",
     params: new Set(["page", "name"]),
     handler: rename_page,
+  },
+  {
+    name: "set-document-title",
+    params: new Set(["title"]),
+    handler: set_document_title,
+  },
+  {
+    name: "save-document",
+    params: new Set<string>([]),
+    handler: save_document,
   },
 ];
 

--- a/packages/drawio-mcp-plugin/src/tools/save-document/index.ts
+++ b/packages/drawio-mcp-plugin/src/tools/save-document/index.ts
@@ -1,0 +1,31 @@
+import type { DrawIOFunction } from "../../types.js";
+
+function normalize_optional_string(value: unknown): string | null {
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+
+  return String(value);
+}
+
+export const save_document: DrawIOFunction = (ui) => {
+  const saveAction = ui?.actions?.get?.("save");
+  if (!saveAction || typeof saveAction.funct !== "function") {
+    throw new Error("The Draw.io save action is not available");
+  }
+  if (
+    typeof saveAction.isEnabled === "function" &&
+    saveAction.isEnabled() !== true
+  ) {
+    throw new Error("The Draw.io save action is currently disabled");
+  }
+
+  saveAction.funct();
+  const file = ui?.getCurrentFile?.();
+
+  return {
+    triggered: true,
+    title: normalize_optional_string(file?.getTitle?.()),
+    mode: normalize_optional_string(file?.getMode?.()),
+  };
+};

--- a/packages/drawio-mcp-plugin/src/tools/set-document-title/index.ts
+++ b/packages/drawio-mcp-plugin/src/tools/set-document-title/index.ts
@@ -1,0 +1,69 @@
+import type { DrawIOFunction, DrawioFile } from "../../types.js";
+
+type RenameableDrawioFile = DrawioFile & {
+  rename?: (
+    title: string,
+    success: () => void,
+    error: (error: unknown) => void,
+  ) => void;
+};
+
+const DRAWIO_FILE_SUFFIX =
+  /(\.drawio\.(?:svg|png)|\.drawio|\.xml|\.svg|\.png)$/i;
+
+function normalize_optional_string(value: unknown): string | null {
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+
+  return String(value);
+}
+
+function title_with_preserved_suffix(
+  currentTitle: string | null,
+  requestedTitle: unknown,
+) {
+  const title = normalize_optional_string(requestedTitle)?.trim() ?? "";
+  if (!title) {
+    throw new Error("`title` must not be empty");
+  }
+
+  const currentSuffix = currentTitle?.match(DRAWIO_FILE_SUFFIX)?.[1] ?? "";
+  if (!currentSuffix || DRAWIO_FILE_SUFFIX.test(title)) {
+    return title;
+  }
+
+  return `${title}${currentSuffix}`;
+}
+
+function tool_error(error: unknown) {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+export const set_document_title: DrawIOFunction = (ui, options) => {
+  const file = ui?.getCurrentFile?.() as RenameableDrawioFile | null;
+  if (!file) {
+    throw new Error("No active Draw.io file is available");
+  }
+  if (typeof file.rename !== "function") {
+    throw new Error("Document renaming is not supported by this storage mode");
+  }
+
+  const previousTitle = normalize_optional_string(file.getTitle?.());
+  const nextTitle = title_with_preserved_suffix(previousTitle, options.title);
+
+  return new Promise<{ previous_title: string | null; title: string }>(
+    (resolve, reject) => {
+      file.rename?.(
+        nextTitle,
+        () => {
+          resolve({
+            previous_title: previousTitle,
+            title: normalize_optional_string(file.getTitle?.()) ?? nextTitle,
+          });
+        },
+        (error: unknown) => reject(tool_error(error)),
+      );
+    },
+  );
+};

--- a/packages/drawio-mcp-server/src/multi-transport.test.ts
+++ b/packages/drawio-mcp-server/src/multi-transport.test.ts
@@ -182,6 +182,9 @@ describe("HTTP transport (stateless per-request)", () => {
 
     const tools = await client.listTools();
     expect(tools.tools.length).toBeGreaterThan(0);
+    expect(tools.tools.map((tool) => tool.name)).toEqual(
+      expect.arrayContaining(["set-document-title", "save-document"]),
+    );
 
     await client.close();
   });

--- a/packages/drawio-mcp-server/src/tool-registry.test.ts
+++ b/packages/drawio-mcp-server/src/tool-registry.test.ts
@@ -36,6 +36,8 @@ describe("shared tool registry", () => {
         "create-page",
         "copy-page",
         "rename-page",
+        "set-document-title",
+        "save-document",
         "import-mermaid",
       ]),
     );
@@ -71,6 +73,13 @@ describe("shared tool registry", () => {
     expect(registry.get("rename-page")?.params.has("target_document")).toBe(
       true,
     );
+    expect(registry.get("set-document-title")?.params.has("title")).toBe(true);
+    expect(
+      registry.get("set-document-title")?.params.has("target_document"),
+    ).toBe(true);
+    expect(registry.get("save-document")?.params.has("target_document")).toBe(
+      true,
+    );
     expect(registry.get("copy-page")?.params.has("page")).toBe(true);
     expect(registry.get("copy-page")?.params.has("target_document")).toBe(true);
     expect(registry.get("import-mermaid")?.params.has("target_page")).toBe(
@@ -85,6 +94,88 @@ describe("shared tool registry", () => {
     expect(
       registry.get("get-shape-by-name")?.params.has("target_document"),
     ).toBe(true);
+  });
+
+  it("renames the current document while preserving its file extension", async () => {
+    await activateDocument();
+    const toolDefinitions = await loadToolDefinitions();
+    const registry = new Map(
+      toolDefinitions.map(
+        (definition) => [definition.name, definition] as const,
+      ),
+    );
+    const handler = registry.get("set-document-title")?.handler;
+    expect(handler).toBeDefined();
+
+    let title = "Untitled Diagram.drawio";
+    const rename = jest.fn(
+      (
+        nextTitle: string,
+        success: () => void,
+        _error: (error: unknown) => void,
+      ) => {
+        title = nextTitle;
+        success();
+      },
+    );
+    const ui = {
+      getCurrentFile: jest.fn(() => ({
+        getTitle: () => title,
+        rename,
+      })),
+    };
+
+    await expect(
+      handler?.(ui, {
+        target_document: { id: "doc-1" },
+        title: "Architecture",
+      }),
+    ).resolves.toEqual({
+      previous_title: "Untitled Diagram.drawio",
+      title: "Architecture.drawio",
+    });
+    expect(rename).toHaveBeenCalledWith(
+      "Architecture.drawio",
+      expect.any(Function),
+      expect.any(Function),
+    );
+  });
+
+  it("triggers the editor's existing save action", async () => {
+    await activateDocument();
+    const toolDefinitions = await loadToolDefinitions();
+    const registry = new Map(
+      toolDefinitions.map(
+        (definition) => [definition.name, definition] as const,
+      ),
+    );
+    const handler = registry.get("save-document")?.handler;
+    expect(handler).toBeDefined();
+
+    const save = jest.fn();
+    const ui = {
+      actions: {
+        get: jest.fn((name: string) =>
+          name === "save" ? { funct: save } : null,
+        ),
+      },
+      getCurrentFile: jest.fn(() => ({
+        getTitle: () => "Architecture.drawio",
+        getMode: () => "device",
+      })),
+    };
+
+    expect(
+      handler?.(ui, {
+        target_document: { id: "doc-1" },
+      }),
+    ).toEqual({
+      triggered: true,
+      title: "Architecture.drawio",
+      mode: "device",
+    });
+    expect(ui.actions.get).toHaveBeenCalledWith("save");
+    expect(save).toHaveBeenCalledTimes(1);
   });
 
   it("classifies background-safe and UI-bound page tools in the shared registry", async () => {

--- a/packages/drawio-mcp-server/src/tools/index.ts
+++ b/packages/drawio-mcp-server/src/tools/index.ts
@@ -23,10 +23,12 @@ import { registerListPagesTool } from "./list-pages.js";
 import { registerListPagedModelTool } from "./list-paged-model.js";
 import { registerMoveCellToLayerTool } from "./move-cell-to-layer.js";
 import { registerRenamePageTool } from "./rename-page.js";
+import { registerSaveDocumentTool } from "./save-document.js";
 import { registerSetActiveLayerTool } from "./set-active-layer.js";
 import { registerSetCellDataTool } from "./set-cell-data.js";
 import { registerSetCellParentTool } from "./set-cell-parent.js";
 import { registerSetCellShapeTool } from "./set-cell-shape.js";
+import { registerSetDocumentTitleTool } from "./set-document-title.js";
 
 const registrars: ToolRegistrar[] = [
   registerGetSelectedCellTool,
@@ -57,6 +59,8 @@ const registrars: ToolRegistrar[] = [
   registerCreatePageTool,
   registerCopyPageTool,
   registerRenamePageTool,
+  registerSetDocumentTitleTool,
+  registerSaveDocumentTool,
 ];
 
 export function registerTools(...args: Parameters<ToolRegistrar>) {

--- a/packages/drawio-mcp-server/src/tools/save-document.ts
+++ b/packages/drawio-mcp-server/src/tools/save-document.ts
@@ -1,0 +1,13 @@
+import { default_tool } from "../tool.js";
+import { ToolRegistrar } from "./types.js";
+
+export const TOOL_save_document = "save-document";
+
+export const registerSaveDocumentTool: ToolRegistrar = (server, context) => {
+  server.tool(
+    TOOL_save_document,
+    "Triggers Draw.io's existing File > Save action for the current document. The active storage provider may display an authentication, conflict, or Save As prompt that requires user interaction.",
+    {},
+    default_tool(TOOL_save_document, context, { queue: true }),
+  );
+};

--- a/packages/drawio-mcp-server/src/tools/set-document-title.ts
+++ b/packages/drawio-mcp-server/src/tools/set-document-title.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+import { default_tool } from "../tool.js";
+import { ToolRegistrar } from "./types.js";
+
+export const TOOL_set_document_title = "set-document-title";
+
+export const registerSetDocumentTitleTool: ToolRegistrar = (
+  server,
+  context,
+) => {
+  server.tool(
+    TOOL_set_document_title,
+    "Renames the current Draw.io document through its active storage provider while preserving the existing file extension when one is present.",
+    {
+      title: z
+        .string()
+        .trim()
+        .min(1)
+        .describe("New document title, with or without the existing extension"),
+    },
+    default_tool(TOOL_set_document_title, context, { queue: true }),
+  );
+};


### PR DESCRIPTION
## Summary

- add `set-document-title` to rename the selected Draw.io document through its active file provider
- preserve the current `.drawio`, `.drawio.svg`, `.drawio.png`, `.xml`, `.svg`, or `.png` suffix when the requested title omits one
- add `save-document` to trigger Draw.io's existing File > Save action in the current storage mode
- route and queue both tools through the existing multi-document infrastructure
- document that provider authentication, conflict, or Save As prompts may still require user interaction

The plugin handlers are isolated under `src/tools/`. They use Draw.io's existing file `rename` callback and save action; no version-specific implementation was needed for the currently supported compatibility window.

## Testing

- drawio-mcp-plugin build
- drawio-mcp-server build
- `build/tool-registry.test.js` — 19 passed
- focused HTTP MCP `tools/list` test — passed
- drawio-mcp-server lint (Biome + TypeScript) — passed
- Prettier check for changed TypeScript files — passed

Closes #57
