### PR TITLE
test(real-environment): assert replace import survives file serialization

### DIFF
--- a/packages/drawio-mcp-server/src/real-environment/import-export.test.ts
+++ b/packages/drawio-mcp-server/src/real-environment/import-export.test.ts
@@ -187,6 +187,56 @@ describe("real environment/import export", () => {
     expect(pageState.graphModelNodeIsNull).toBe(true);
     expect(pageState.pageRootHasImportedCell).toBe(true);
 
+    // The page-root identity asserted above is a proxy for correctness. What a
+    // user actually loses when currentPage goes stale is the *serialized* file:
+    // drawio serializes through the Page abstraction, so a stale page root ends
+    // up in the saved bytes while the live graph (holding the import) does not.
+    // Assert the import survives serialization, not just the in-memory model.
+    const serializedFileData = await context.page.evaluate(() => {
+      const maybeWindow = window as any;
+      const ui = maybeWindow.ui;
+
+      try {
+        if (
+          typeof ui?.getXmlFileData === "function" &&
+          typeof maybeWindow.mxUtils?.getXml === "function"
+        ) {
+          return String(
+            maybeWindow.mxUtils.getXml(ui.getXmlFileData(true, false, true)),
+          );
+        }
+      } catch {
+        /* fall through to getFileData */
+      }
+
+      try {
+        if (typeof ui?.getFileData === "function") {
+          return String(
+            ui.getFileData(
+              true,
+              null,
+              null,
+              null,
+              true,
+              null,
+              null,
+              null,
+              null,
+              true,
+            ),
+          );
+        }
+      } catch {
+        /* unsupported build */
+      }
+
+      return null;
+    });
+
+    if (serializedFileData !== null) {
+      expect(serializedFileData).toContain("Regression cell");
+    }
+
     const survivesPageRoundTrip = await context.page.evaluate(async () => {
       const maybeWindow = window as any;
       const ui = maybeWindow.ui;


### PR DESCRIPTION
## What

Extends the existing #56 regression test in `packages/drawio-mcp-server/src/real-environment/import-export.test.ts` with one more assertion: after an `import-diagram` `mode: "replace"`, the **serialized file data** must contain the imported cell — not just the in-memory model.

Test-only; no production code is touched.

## Why

c4ba6a4 fixed the stale `ui.currentPage` after a replace import, and the current regression test guards it by asserting page/model root identity:

```ts
expect(pageState.pageRootMatchesModelRoot).toBe(true);
expect(pageState.graphModelNodeIsNull).toBe(true);
expect(pageState.pageRootHasImportedCell).toBe(true);
```

Those are the right invariants, but they are a *proxy* for what a user actually loses. drawio serializes through the Page abstraction, so when `currentPage` is stale the damage lands one layer further out: the live graph holds the import, the saved bytes hold the pre-import content, and the save reports success.

On the published v2.2.0 (which predates c4ba6a4) that is exactly the observed failure on a cloud-backed document — the model was correct and `list-paged-model` confirmed the imported cells, but saving and reloading returned the document to its pre-import state, silently. See #64 for the full reproduction and a discriminating experiment showing the trigger is the root-object replacement (`add-rectangle` persisted through the same save; `import-diagram replace` did not).

This assertion covers that layer directly, so a future regression that keeps the root identity correct but still serializes the wrong page would be caught here rather than in a user's file.

## How

The check is defensive in the same style as the surrounding test: it prefers `getXmlFileData` + `mxUtils.getXml`, falls back to `getFileData` with `uncompressed = true`, and skips the assertion entirely if neither shape is available on the build under test — so it will not fail on drawio versions exposing a different serialization API.

I verified the assertion actually executes rather than silently skipping: with a temporary `expect(serializedFileData).not.toBeNull()` added, the test still passed on the current harness, so the `toContain` check is really running.

## Testing

```
pnpm --filter drawio-mcp-server test  # (ran the import-export suite specifically)
```

```
PASS build/real-environment/import-export.test.js
  real environment/import export
    ✓ covers xml export to file and xml import into the live diagram
    ✓ keeps ui.currentPage.root in sync with graph.model.root after replace import (regression for #56)
```

`prettier --check`, `biome check src/` and `tsc --noEmit` all clean.

## Related

- #56 — the rendering symptom of the same stale-`currentPage` cause
- #64 — the data-loss symptom on cloud-backed files in v2.2.0
