### PR TITLE
docs: fix broken star history chart by migrating to star-history.dera.page

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,11 @@ See [DESKTOP.md](./DESKTOP.md) for the full setup steps and the current limitati
 
 ## Star History
 
-<a href="https://star-history.com/#lgazo/drawio-mcp-server&Date">
+<a href="https://star-history.dera.page/#lgazo/drawio-mcp-server&type=Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=lgazo/drawio-mcp-server&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=lgazo/drawio-mcp-server&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=lgazo/drawio-mcp-server&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=lgazo/drawio-mcp-server&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=lgazo/drawio-mcp-server&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=lgazo/drawio-mcp-server&type=Date" />
  </picture>
 </a>
 

--- a/packages/drawio-mcp-server/README.md
+++ b/packages/drawio-mcp-server/README.md
@@ -223,11 +223,11 @@ See [DESKTOP.md](./DESKTOP.md) for the full setup steps and the current limitati
 
 ## Star History
 
-<a href="https://star-history.com/#lgazo/drawio-mcp-server&Date">
+<a href="https://star-history.dera.page/#lgazo/drawio-mcp-server&type=Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=lgazo/drawio-mcp-server&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=lgazo/drawio-mcp-server&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=lgazo/drawio-mcp-server&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=lgazo/drawio-mcp-server&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=lgazo/drawio-mcp-server&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=lgazo/drawio-mcp-server&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions in the previous provider. This PR fixes it by switching the chart and its wrapping link to the star-history.dera.page fork, which uses an alternative data source that requires no API token.

The chart section in both the root README and the packages-drawio-mcp-server README now points to star-history.dera.page, with the wrapping link converted to the hash-based URL format.